### PR TITLE
Add files via upload

### DIFF
--- a/onboarding.md
+++ b/onboarding.md
@@ -1,0 +1,39 @@
+# Return - IT onboarding
+
+Hello and welcome to Return!
+
+To get you fully up and running, there are a couple IT things you have to do first.
+
+## Security policy
+
+Please read the and complete the [Return Information Security Guidelines form](https://docs.google.com/forms/d/e/1FAIpQLSecrcx2V-Ts8sifJlMK9IJ1SNy-3ns3asONO7dPRE3_pTWevA/viewform) to confirm you have understood the policy. Please refer to [Return security guidelines](https://platform.return.energy/hub/pages/information_security_guidelines) when you want to read the security guidelines again.
+
+## Laptop and Microsoft account
+
+You will be provided with a temporary password provided by your point of contact to access your laptop. Please follow the setup, changing your password and configuring multi-factor authentication following the security policy. You are encouraged to use biometric verification (via fingerprint or facial recognition). You also use this account to use Microsoft Office applications (Word, Excel, etc.).
+
+## Return platform
+
+Please sign in to the [Return platform](https://platform.return.energy/), select "Hub" and follow the instructions to create your profile. There are detailed instructions on the applications mentioned below (and more) in the [documents](https://platform.return.energy/hub/pages) section.
+
+## Google Workspace: step one
+
+Return uses Google Workspace for email, calendar and real time collaboration. Your point of contact will provide you with a temporary password to sign-in to your account (via <https://accounts.google.com>). You will be required to change it into a personalised password and enable multi-factor authentication using the Google Authenticator app.
+
+## Dashlane
+
+In your Google mail inbox (<https://mail.google.com/mail/>), you will find an invite to Dashlane. Return uses Dashlane as its password manager. Use Dashlane to generate and store strong passwords. Please follow the instructions from the Dashlane email. Afterwards, sign in to the Dashlane browser extension by clicking on the Dashlane icon in the top right corner of your Chrome browser.
+
+## Google Workspace: step two
+
+On <https://myaccount.google.com/u/0/security> update your Google Workspace password by generating one with Dashlane.
+
+## Box
+
+Return uses Box for file storage and sharing. Your point of contact will provide you with a temporary password to sign-in to your account (via <https://box.com>). You will then be required to enable multi-factor authentication. After doing so, please change your password using Dashlane by clicking on your initials in the top right corner of the Box website. Then select “Account settings” and scroll down until you see the option to change your password.
+
+Finally, click on the Start button on your taskbar and open the Box Drive application (which should be visible right away).
+
+## Slack
+
+Return uses Slack for internal communication. Please sign-in to Slack by clicking on the Slack icon on your taskbar and sign-in using your Google Workspace account. You will be prompted to sign-in the first time you open the application.


### PR DESCRIPTION
In the “return onboarding,” the link titled “documents” under Return Platform does not work and says “The page you are looking for does not exist”

Under the “box” section, the two middle sentences should be flipped. Actually, one can be deleted as they say the same thing. 

Slack was not present on the taskbar so had to be downloaded first
